### PR TITLE
feat: configure max message receive size

### DIFF
--- a/cli/runtimeconfig.go
+++ b/cli/runtimeconfig.go
@@ -13,13 +13,17 @@ type RuntimeConfig struct {
 	Address     string
 	Host        map[string]*bool
 	DefaultHost string
+	MaxRecvSize int
 }
+
+const defaultMaxRecvSize = 1024 * 1024 * 4 // 4 Mb
 
 func (c *RuntimeConfig) AddToFlagSet(flags *pflag.FlagSet, compiler CompilerConfig) {
 	flags.BoolVarP(&c.Verbose, "verbose", "v", false, "print verbose output")
 	flags.BoolVar(&c.Insecure, "insecure", false, "make insecure client connection (only on localhost)")
 	flags.StringVar(&c.Address, "address", "", "address to connect to")
 	flags.StringVar(&c.Token, "token", "", "bearer token used by client")
+	flags.IntVar(&c.MaxRecvSize, "max-rcv-size", defaultMaxRecvSize, "maximum message size in bytes the client can receive")
 	c.Host = map[string]*bool{}
 	for host, address := range compiler.Hosts {
 		if flag := flags.Lookup(host); flag == nil {


### PR DESCRIPTION
Useful when fetching large messages. Defaults to 4 MB.